### PR TITLE
plotnine 0.12.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "plotnine" %}
 {% set version = "0.12.1" %}
-{% set bundle = "tar.gz" %}
 {% set hash = "be852c6e50e331ad250151dc4120f269ee9ae5e795f67030f7794718b502592a" %}
 
 package:
@@ -8,32 +7,30 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  sha256: {{ hash }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: be852c6e50e331ad250151dc4120f269ee9ae5e795f67030f7794718b502592a
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  noarch: python
+  number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8.0
+    - python
     - pip
     - setuptools
     - setuptools_scm
-
+    - wheel
   run:
-    - python >=3.8.0
+    - python
+    - {{ pin_compatible('numpy') }}
     - matplotlib-base >=3.6.0
     - mizani >=0.9.0
-    - numpy >=1.23.0
     - pandas >=1.5.0
     - patsy >=0.5.1
     - scipy >=1.5.0
     - statsmodels >=0.14.0
-    # - geopandas >=0.3.0
 
 test:
   requires:
@@ -54,22 +51,21 @@ test:
     - plotnine.stats
     - plotnine.themes
   source_files:
-    - "tests"
+    - tests
     - "pyproject.toml"
   commands:
-    # The pip version can reported incorrectly if setuptools_scm isn't available
-    # at build time
-    - pip list | grep -i {{ name }} | grep {{ version }}
     - pip check
-    - echo $PWD
-    - ls -larth
-    # - pytest
+    - pytest tests -vv
 
 about:
   home: https://github.com/has2k1/plotnine
   license_file: {{ RECIPE_DIR }}/LICENSE
   license: MIT
+  license_family: MIT
   summary: A grammar of graphics for python
+  description: |
+    plotnine is an implementation of a grammar of graphics in Python based on ggplot2. 
+    The grammar allows you to compose plots by explicitly mapping variables in a dataframe to the visual objects that make up the plot.
   dev_url: https://github.com/has2k1/plotnine
   doc_url: https://plotnine.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
 
 build:
   number: 0
-  # geopandas isn't available on s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -38,7 +37,8 @@ test:
     - pip
     - pytest
     - pytest-cov
-    - geopandas  # [py<310]
+    # geopandas isn't available on s390x
+    - geopandas  # [py<310 or s390x]
   imports:
     - plotnine
     - plotnine.coords

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,9 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
     - matplotlib-base >=3.6.0
     - mizani >=0.9.0
+    - numpy >=1.23.0
     - pandas >=1.5.0
     - patsy >=0.5.1
     - scipy >=1.5.0
@@ -55,7 +55,9 @@ test:
     - tests
     - "pyproject.toml"
   commands:
-    - pip check
+    # Disable pip check because of mizani 0.9.2 requires tzdata, which is not installed,
+    # see also https://github.com/AnacondaRecipes/mizani-feedstock/pull/3#issue-1812052144
+    - pip check  # [not win]
     # Disable pytest because a lot of tests has an error 'assert images not close',
     # see the upstream issue https://github.com/has2k1/plotnine/issues/627
     # conda-forge also disables pytest https://github.com/conda-forge/plotnine-feedstock/commit/5d559dbd9a09b83cd74a55ea11587cbff29eef64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - pytest
     - pytest-cov
     # geopandas isn't available on s390x
-    - geopandas  # [py<310 or s390x]
+    - geopandas  # [py<310 or not (linux and s390x)]
   imports:
     - plotnine
     - plotnine.coords

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pip
     - pytest
     - pytest-cov
-    - geopandas
+    - geopandas  # [py<311]
   imports:
     - plotnine
     - plotnine.coords

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  # geopandas isn't available on s390x
+  skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -55,7 +56,10 @@ test:
     - "pyproject.toml"
   commands:
     - pip check
-    - pytest tests -vv
+    # Disable pytest because a lot of tests has an error 'assert images not close',
+    # see the upstream issue https://github.com/has2k1/plotnine/issues/627
+    # conda-forge also disables pytest https://github.com/conda-forge/plotnine-feedstock/commit/5d559dbd9a09b83cd74a55ea11587cbff29eef64
+    #- pytest tests -vv
 
 about:
   home: https://github.com/has2k1/plotnine

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - pytest
     - pytest-cov
     # geopandas isn't available on s390x
-    - geopandas  # [py<310 or not (linux and s390x)]
+    - geopandas  # [py<310 and not (linux and s390x)]
   imports:
     - plotnine
     - plotnine.coords

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - pip
     - pytest
     - pytest-cov
-    - geopandas  # [py<311]
+    - geopandas  # [py<310]
   imports:
     - plotnine
     - plotnine.coords


### PR DESCRIPTION
Changelog: https://github.com/has2k1/plotnine/releases
License: https://github.com/has2k1/plotnine/blob/v0.12.1/LICENSE
Requirements: https://github.com/has2k1/plotnine/blob/v0.12.1/pyproject.toml

Actions:
1. Clean up the recipe:
- Remove unused jinja2 variables
- Remove `noarch` python
- Skip `py<37`
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `wheel` to `host`
- Fix `python` in `host` and `run`
2. Disable `pip check` on `win` because of `mizani` and `tzdata`, see https://github.com/AnacondaRecipes/mizani-feedstock/pull/3#issue-1812052144
3. Remove debug code from `test/commands`
4. Add `license_family`
5. Add `description`